### PR TITLE
fix: quizdidaktik_spider

### DIFF
--- a/sources.ttl
+++ b/sources.ttl
@@ -735,7 +735,7 @@
     sdo:url <https://www.youtube.com/channel/UC9K6m29pOxYU6F2qLrCcIBQ/featured> .
 
 <993c409c-b1f8-406d-9b93-d5b573f537c3> a skos:Concept ;
-    skos:notation "irights_spider"^^xsd:string ;
+    skos:notation "quizdidaktik_spider"^^xsd:string ;
     skos:prefLabel "Quizdidaktik"@de ;
     skos:topConceptOf <> ;
     sdo:url <https://quizdidaktik.de/> .


### PR DESCRIPTION
"irights_spider" had a mapping for "quizdidaktik" and "quizdidaktik_spider" was missing completely