### PR TITLE
change: prefLabel "ZUM - Apps" to "ZUM-Apps"

### DIFF
--- a/sources.ttl
+++ b/sources.ttl
@@ -1104,7 +1104,7 @@
     sdo:url <https://video.uni-mainz.de/> .
 
 <ec923c57-2ac3-4245-8cc1-30fe8c5216e3> a skos:Concept ;
-    skos:prefLabel "ZUM - Apps"@de ;
+    skos:prefLabel "ZUM-Apps"@de ;
     skos:topConceptOf <> ;
     sdo:url <https://apps.zum.de> .
 


### PR DESCRIPTION
- change prefLabel according to ZUM's own naming convention
    - this change was made due to the user request from Slack #wlo_3_user_support (see: https://oede.slack.com/archives/C0188VBRNQ0/p1652437569697269)