### PR TITLE
add: dwu_spider

### DIFF
--- a/sources.ttl
+++ b/sources.ttl
@@ -1253,6 +1253,12 @@
     skos:topConceptOf <> ;
     sdo:url <https://oersi.org/> .
 
+<2c34f4cb-3bac-483a-b6a7-f25c0fdacc5e> a skos:Concept ;
+    skos:notation "dwu_spider"^^xsd:string ;
+    skos:prefLabel "dwu-Unterrichtsmaterialien"@de ;
+    skos:topConceptOf <> ;
+    sdo:url <https://www.dwu-unterrichtsmaterialien.de> .
+
 <f5da1c8f-094a-4914-a9a6-4fb123d598c5> a skos:Concept ;
     skos:narrower <0a27ef7c-1f88-4021-87cd-e39b155d9e5b>,
         <0b96a426-eac4-4c24-845f-85eeb74fd41a>,
@@ -1487,4 +1493,5 @@
 		<011766b1-07f8-4cbe-bef1-3316458ed7cb>,
         <5dfac971-25a1-4c05-b1cd-94b62f50dbad>,
         <10911b79-c770-46f3-a899-91ea2b562c86>,
-        <31400357-3a24-4bfe-9ea8-281344a5ee90>.
+        <31400357-3a24-4bfe-9ea8-281344a5ee90>,
+        <2c34f4cb-3bac-483a-b6a7-f25c0fdacc5e>.


### PR DESCRIPTION
- Dieter Welz informed us that his materials won't be available anymore on ZUM servers, ~~therefore the crawler entry needed to be updated~~

After our short meeting (2022-12-15), I made the following change to this PullRequest:
- as a safety-precaution, "dwu_spider" got a separate entry in the `sources.ttl`-Vocab
  - the previous "zum_dwu_spider"-entry stays untouched

See: https://issues.edu-sharing.net/jira/browse/SD_WLO-525