### PR TITLE
fix: typo in science_in_school_spider entry

### DIFF
--- a/sources.ttl
+++ b/sources.ttl
@@ -1255,7 +1255,7 @@
     sdo:url <https://www.dwu-unterrichtsmaterialien.de> .
 
 <57addf1b-cf6e-437b-a9f1-93c19c614a76> a skos:Concept ;
-    skos:notation "<science_in_school_spider>"^^xsd:string ;
+    skos:notation "science_in_school_spider"^^xsd:string ;
     skos:prefLabel "Science in School"@de ;
     skos:topConceptOf <> ;
     sdo:url <https://www.scienceinschool.org> .


### PR DESCRIPTION
- fix: autocomplete typo in `science_in_school_spider`-entry in ´sources.ttl`