### PR TITLE
Added lom based value spaces

### DIFF
--- a/lom_aggregationlevel.ttl
+++ b/lom_aggregationlevel.ttl
@@ -1,0 +1,42 @@
+@base <http://w3id.org/openeduhub/vocabs/lom_aggregationlevel/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<> a skos:ConceptScheme;
+    dct:title "LOM -  General.AggregationLevel"@de;
+    dct:title "LOM -  General.AggregationLevel"@en;
+    dct:description "Wertebereich für das Aggregationsniveau einer Lernressource gemäß dem LOM-Standard."@de;
+    dct:description "Value range for the aggregation level of a learning resource according to the LOM standard."@en;
+    dct:creator "<https://wirlernenonline.de>" ;
+    dct:created "2024-02-23"^^xsd:date;
+    dct:license <http://creativecommons.org/publicdomain/zero/1.0/> ;
+    skos:hasTopConcept <level_1>, <level_2>, <level_3>, <level_4> .
+
+<level_1> a skos:Concept ;
+    skos:prefLabel "level 1"@en ;
+    skos:prefLabel "Level 1"@de ;
+    skos:definition "The smallest aggregation level of a learning resource, e.g. raw media data or fragments."@en ;
+    skos:definition "Das kleinste Aggregationsniveau einer Lernressource, z.B. Medienrohdaten oder Fragmente."@de ;
+    skos:topConceptOf <> .
+
+<level_2> a skos:Concept ;
+    skos:prefLabel "level 2"@en ;
+    skos:prefLabel "Level 2"@de ;
+    skos:definition "A collection of level 1 learning objects, e.g. a lesson."@en ;
+    skos:definition "Eine Sammlung von Lernobjekten der Ebene 1, z.B. eine Lektion."@de ;
+    skos:topConceptOf <> .
+
+<level_3> a skos:Concept ;
+    skos:prefLabel "level 3"@en ;
+    skos:prefLabel "Level 3"@de ;
+    skos:definition "A collection of level 2 learning objects, e.g. a course."@en ;
+    skos:definition "Eine Sammlung von Lernobjekten der Ebene 2, z.B. ein Kurs."@de ;
+    skos:topConceptOf <> .
+
+<level_4> a skos:Concept ;
+    skos:prefLabel "level 4"@en ;
+    skos:prefLabel "Level 4"@de ;
+    skos:definition "the largest level of granularity, e.g. a set of courses that lead to a certificate."@en ;
+    skos:definition "Die höchste Granularitätsebene, z. B. eine Reihe von Kursen, die zu einem Zertifikat führen."@de ;
+    skos:topConceptOf <> .

--- a/lom_copyright_and_other_restrictions.ttl
+++ b/lom_copyright_and_other_restrictions.ttl
@@ -1,0 +1,24 @@
+@base <http://w3id.org/openeduhub/vocabs/lom_copyright_and_other_restrictions/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<> a skos:ConceptScheme ;
+    dct:title "LOM - Rights.CopyrightAndOtherRestrictions"@en;
+    dct:title "LOM - Rights.CopyrightAndOtherRestrictions"@de;
+    dct:description "Whether copyright or other restrictions apply to the use of this learning object."@en ;
+    dct:description "Gelten urheberrechtliche oder andere Einschränkungen für die Nutzung dieses Lernobjekts"@de ;
+    dct:creator "<https://wirlernenonline.de>" ;
+    dct:created "2024-02-23"^^xsd:date;
+    dct:license <http://creativecommons.org/publicdomain/zero/1.0/> ;
+    skos:hasTopConcept <yes>, <no> .
+
+<yes> a skos:Concept ;
+    skos:prefLabel "yes"@en ;
+    skos:prefLabel "ja"@de ;
+    skos:topConceptOf <> .
+
+<no> a skos:Concept ;
+    skos:prefLabel "no"@en ;
+    skos:prefLabel "nein"@de ;
+    skos:topConceptOf <> .

--- a/lom_cost.ttl
+++ b/lom_cost.ttl
@@ -1,0 +1,24 @@
+@base <http://w3id.org/openeduhub/vocabs/lom_cost/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<> a skos:ConceptScheme ;
+    dct:title "LOM - Rights.Cost"@en;
+    dct:title "LOM - Rights.Cost"@de;
+    dct:description "Whether use of this learning object requires payment."@en ;
+    dct:description "Ist die Nutzung dieses Lernobjekts kostenpflichtig."@de ;
+    dct:creator "<https://wirlernenonline.de>" ;
+    dct:created "2024-02-23"^^xsd:date;
+    dct:license <http://creativecommons.org/publicdomain/zero/1.0/> ;
+    skos:hasTopConcept <yes>, <no> .
+
+<yes> a skos:Concept ;
+    skos:prefLabel "yes"@en ;
+    skos:prefLabel "ja"@de ;
+    skos:topConceptOf <> .
+
+<no> a skos:Concept ;
+    skos:prefLabel "no"@en ;
+    skos:prefLabel "nein"@de ;
+    skos:topConceptOf <> .

--- a/lom_educational_context.ttl
+++ b/lom_educational_context.ttl
@@ -1,0 +1,32 @@
+@base <http://w3id.org/openeduhub/vocabs/lom_educational-context/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<> a skos:ConceptScheme;
+    dct:title "LOM - Educational.Context"@en;
+    dct:title "LOM - Educational.Context"@de;
+    dct:creator "<https://wirlernenonline.de>" ;
+    dct:created "2024-02-23"^^xsd:date;
+    dct:license <http://creativecommons.org/publicdomain/zero/1.0/> ;
+    skos:hasTopConcept <school>, <higher_education>, <training>, <other> .
+
+<school> a skos:Concept ;
+    skos:prefLabel "School"@en ;
+    skos:prefLabel "Schule"@de ;
+    skos:topConceptOf <> .
+
+<higher_education> a skos:Concept ;
+    skos:prefLabel "Higher Education"@en ;
+    skos:prefLabel "Höhere Bildung"@de ;
+    skos:topConceptOf <> .
+
+<training> a skos:Concept ;
+    skos:prefLabel "Training"@en ;
+    skos:prefLabel "Ausbildung"@de ;
+    skos:topConceptOf <> .
+
+<other> a skos:Concept ;
+    skos:prefLabel "Other"@en ;
+    skos:prefLabel "Andere"@de ;
+    skos:topConceptOf <> .

--- a/lom_educational_difficulty.ttl
+++ b/lom_educational_difficulty.ttl
@@ -1,0 +1,32 @@
+@base <http://w3id.org/openeduhub/vocabs/lom_educational_difficulty/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<> a skos:ConceptScheme;
+    dct:title "LOM - Educational.Difficulty"@en;
+    dct:title "LOM - Educational.Difficulty"@de;
+    dct:creator "<https://wirlernenonline.de>" ;
+    dct:created "2024-02-23"^^xsd:date;
+    dct:license <http://creativecommons.org/publicdomain/zero/1.0/> ;
+    skos:hasTopConcept <very_easy>, <easy>, <medium>, <difficult>, <very_difficult> .
+
+<very_easy> a skos:Concept ;
+    skos:prefLabel "Very Easy"@en, "Sehr einfach"@de ;
+    skos:topConceptOf <> .
+
+<easy> a skos:Concept ;
+    skos:prefLabel "Easy"@en, "Einfach"@de ;
+    skos:topConceptOf <> .
+
+<medium> a skos:Concept ;
+    skos:prefLabel "Medium"@en, "Mittel"@de ;
+    skos:topConceptOf <> .
+
+<difficult> a skos:Concept ;
+    skos:prefLabel "Difficult"@en, "Schwierig"@de ;
+    skos:topConceptOf <> .
+
+<very_difficult> a skos:Concept ;
+    skos:prefLabel "Very Difficult"@en, "Sehr schwierig"@de ;
+    skos:topConceptOf <> .

--- a/lom_intended_end_user_role.ttl
+++ b/lom_intended_end_user_role.ttl
@@ -1,0 +1,49 @@
+@base <http://w3id.org/openeduhub/vocabs/lom_intended_end_user_role/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<> a skos:ConceptScheme;
+    dct:title "LOM - Educational.IntendedEndUserRole"@en;
+    dct:title "LOM - Educational.IntendedEndUserRole"@de;
+    dct:description "Value range for the intended end user role of a learning resource according to the LOM 1.0 standard."@en;
+    dct:description "Wertebereich für die beabsichtigte Endbenutzerrolle einer Lernressource gemäß dem LOM 1.0-Standard."@de;
+    dct:creator "<https://wirlernenonline.de>" ;
+    dct:created "2024-02-23"^^xsd:date;
+    dct:license <http://creativecommons.org/publicdomain/zero/1.0/> ;
+    skos:hasTopConcept <teacher>, <author>, <learner>, <manager>, <parent>, <counsellor>, <other> .
+
+<teacher> a skos:Concept ;
+    skos:prefLabel "Teacher"@en ;
+    skos:prefLabel "Lehrer*in"@de ;
+    skos:topConceptOf <> .
+
+<author> a skos:Concept ;
+    skos:prefLabel "Author"@en ;
+    skos:prefLabel "Autor*in"@de ;
+    skos:topConceptOf <> .
+
+<learner> a skos:Concept ;
+    skos:prefLabel "Learner"@en ;
+    skos:prefLabel "Lerner*in"@de ;
+    skos:topConceptOf <> .
+
+<manager> a skos:Concept ;
+    skos:prefLabel "Manager"@en ;
+    skos:prefLabel "Manager*in"@de ;
+    skos:topConceptOf <> .
+
+<parent> a skos:Concept ;
+    skos:prefLabel "Parent"@en ;
+    skos:prefLabel "Elternteil"@de ;
+    skos:topConceptOf <> .
+
+<counsellor> a skos:Concept ;
+    skos:prefLabel "Counsellor"@en ;
+    skos:prefLabel "Berater*in"@de ;
+    skos:topConceptOf <> .
+
+<other> a skos:Concept ;
+    skos:prefLabel "Other"@en ;
+    skos:prefLabel "Andere"@de ;
+    skos:topConceptOf <> .

--- a/lom_interactivity_level.ttl
+++ b/lom_interactivity_level.ttl
@@ -1,0 +1,49 @@
+@base <http://w3id.org/openeduhub/vocabs/lom_interactivity_level/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<> a skos:ConceptScheme;
+    dct:title "LOM - Educational.InteractivityLevel"@en;
+    dct:title "LOM - Educational.InteractivityLevel"@de;
+    dct:description "Value range for the interactivity level of a learning resource according to the LOM standard."@en;
+    dct:description "Wertebereich für das Interaktivitätsniveau einer Lernressource gemäß dem LOM-Standard."@de;
+    dct:creator "<https://wirlernenonline.de>" ;
+    dct:created "2024-02-23"^^xsd:date;
+    dct:license <http://creativecommons.org/publicdomain/zero/1.0/> ;
+    skos:hasTopConcept <very_low>, <low>, <medium>, <high>, <very_high> .
+
+<very_low> a skos:Concept ;
+    skos:prefLabel "Very Low"@en ;
+    skos:prefLabel "Sehr gering"@de ;
+    skos:definition "Practically no interactivity."@en ;
+    skos:definition "Praktisch keine Interaktivität."@de ;
+    skos:topConceptOf <> .
+
+<low> a skos:Concept ;
+    skos:prefLabel "Low"@en ;
+    skos:prefLabel "Gering"@de ;
+    skos:definition "Limited interactivity."@en ;
+    skos:definition "Begrenzte Interaktivität."@de ;
+    skos:topConceptOf <> .
+
+<medium> a skos:Concept ;
+    skos:prefLabel "Medium"@en ;
+    skos:prefLabel "Mittel"@de ;
+    skos:definition "Some interactivity."@en ;
+    skos:definition "Einige Interaktivität."@de ;
+    skos:topConceptOf <> .
+
+<high> a skos:Concept ;
+    skos:prefLabel "High"@en ;
+    skos:prefLabel "Hoch"@de ;
+    skos:definition "Significant interactivity."@en ;
+    skos:definition "Signifikante Interaktivität."@de ;
+    skos:topConceptOf <> .
+
+<very_high> a skos:Concept ;
+    skos:prefLabel "Very High"@en ;
+    skos:prefLabel "Sehr hoch"@de ;
+    skos:definition "Very high level of interactivity."@en ;
+    skos:definition "Sehr hohes Niveau an Interaktivität."@de ;
+    skos:topConceptOf <> .

--- a/lom_interactivity_type.ttl
+++ b/lom_interactivity_type.ttl
@@ -1,0 +1,29 @@
+@base <http://w3id.org/openeduhub/vocabs/lom_interactivity_type/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<> a skos:ConceptScheme ;
+    dct:title "LOM - Educational.InteractivityType"@de;
+    dct:title "LOM - Educational.InteractivityType"@en;
+    dct:description "Definition of a learning object according to the interactivity type."@en;
+    dct:description "Definition eines Lernobjekts nach dem Interaktivitätstyp, gemäß dem LOM-Standard."@de;
+    dct:creator "<https://wirlernenonline.de>" ;
+    dct:created "2024-02-23"^^xsd:date;
+    dct:license <http://creativecommons.org/publicdomain/zero/1.0/> ;
+    skos:hasTopConcept <active>, <expositive>, <mixed> .
+
+<active> a skos:Concept ;
+    skos:prefLabel "aktiv"@de ;
+    skos:prefLabel "active"@en ;
+    skos:topConceptOf <> .
+
+<expositive> a skos:Concept ;
+    skos:prefLabel "darstellend"@de ;
+    skos:prefLabel "expositive"@en ;
+    skos:topConceptOf <> .
+
+<mixed> a skos:Concept ;
+    skos:prefLabel "gemischt"@de ;
+    skos:prefLabel "mixed"@en ;
+    skos:topConceptOf <> .

--- a/lom_learning_resource_type.ttl
+++ b/lom_learning_resource_type.ttl
@@ -1,0 +1,126 @@
+@base <http://w3id.org/openeduhub/vocabs/lom_learning_resource_type/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<> a skos:ConceptScheme;
+    dct:title "LOM - Educational.LearningResourceType"@en;
+    dct:title "LOM - Educational.LearningResourceType"@de;
+    dct:description "Value range for the type of a learning resource according to the LOM standard."@en;
+    dct:description "Wertebereich für den Typ einer Lernressource gemäß dem LOM-Standard."@de;
+    dct:creator "<https://wirlernenonline.de>" ;
+    dct:created "2024-02-23"^^xsd:date;
+    dct:license <http://creativecommons.org/publicdomain/zero/1.0/> ;
+    skos:hasTopConcept <exercise>, <simulation>, <questionnaire>, <diagram>, <figure>, <graph>, <index>, <slide>, <table>, <narrative_text>, <exam>, <experiment>, <problem_statement>, <self_assessment>, <lecture>, <reading> .
+
+<exercise> a skos:Concept ;
+    skos:prefLabel "Exercise"@en ;
+    skos:prefLabel "Übung"@de ;
+    skos:definition "An interactive learning activity designed to reinforce learning."@en ;
+    skos:definition "Eine interaktive Lernaktivität, die dazu dient, das Lernen zu verstärken."@de ;
+    skos:topConceptOf <> .
+
+<simulation> a skos:Concept ;
+    skos:prefLabel "Simulation"@en ;
+    skos:prefLabel "Simulation"@de ;
+    skos:definition "A representation of a real-world process or system."@en ;
+    skos:definition "Eine Darstellung eines realen Prozesses oder Systems."@de ;
+    skos:topConceptOf <> .
+
+<questionnaire> a skos:Concept ;
+    skos:prefLabel "Questionnaire"@en ;
+    skos:prefLabel "Fragebogen"@de ;
+    skos:definition "A set of questions used for gathering information or feedback."@en ;
+    skos:definition "Eine Reihe von Fragen zur Erfassung von Informationen oder Feedback."@de ;
+    skos:topConceptOf <> .
+
+<diagram> a skos:Concept ;
+    skos:prefLabel "Diagram"@en ;
+    skos:prefLabel "Diagramm"@de ;
+    skos:definition "A graphical representation of information or data."@en ;
+    skos:definition "Eine grafische Darstellung von Informationen oder Daten."@de ;
+    skos:topConceptOf <> .
+
+<figure> a skos:Concept ;
+    skos:prefLabel "Figure"@en ;
+    skos:prefLabel "Abbildung"@de ;
+    skos:definition "A visual illustration or representation."@en ;
+    skos:definition "Eine visuelle Darstellung oder Abbildung."@de ;
+    skos:topConceptOf <> .
+
+<graph> a skos:Concept ;
+    skos:prefLabel "Graph"@en ;
+    skos:prefLabel "Graph"@de ;
+    skos:definition "A visual representation of mathematical relationships or data."@en ;
+    skos:definition "Eine visuelle Darstellung mathematischer Beziehungen oder Daten."@de ;
+    skos:topConceptOf <> .
+
+<index> a skos:Concept ;
+    skos:prefLabel "Index"@en ;
+    skos:prefLabel "Index"@de ;
+    skos:definition "An alphabetical list of terms or topics with references to where they occur."@en ;
+    skos:definition "Eine alphabetische Liste von Begriffen oder Themen mit Verweisen auf ihre Vorkommen."@de ;
+    skos:topConceptOf <> .
+
+<slide> a skos:Concept ;
+    skos:prefLabel "Slide"@en ;
+    skos:prefLabel "Folie"@de ;
+    skos:definition "A single page or screen in a presentation."@en ;
+    skos:definition "Eine einzelne Seite oder Bildschirm in einer Präsentation."@de ;
+    skos:topConceptOf <> .
+
+<table> a skos:Concept ;
+    skos:prefLabel "Table"@en ;
+    skos:prefLabel "Tabelle"@de ;
+    skos:definition "A set of data organized in rows and columns."@en ;
+    skos:definition "Eine Menge von Daten, die in Zeilen und Spalten organisiert sind."@de ;
+    skos:topConceptOf <> .
+
+<narrative_text> a skos:Concept ;
+    skos:prefLabel "Narrative Text"@en ;
+    skos:prefLabel "Erzählender Text"@de ;
+    skos:definition "Text that tells a story or conveys information in a sequential manner."@en ;
+    skos:definition "Text, der eine Geschichte erzählt oder Informationen in sequentieller Weise vermittelt."@de ;
+    skos:topConceptOf <> .
+
+<exam> a skos:Concept ;
+    skos:prefLabel "Exam"@en ;
+    skos:prefLabel "Prüfung"@de ;
+    skos:definition "A formal test of knowledge or proficiency."@en ;
+    skos:definition "Ein formaler Test des Wissens oder der Fähigkeiten."@de ;
+    skos:topConceptOf <> .
+
+<experiment> a skos:Concept ;
+    skos:prefLabel "Experiment"@en ;
+    skos:prefLabel "Experiment"@de ;
+    skos:definition "A scientific procedure undertaken to make a discovery, test a hypothesis, or demonstrate a known fact."@en ;
+    skos:definition "Ein wissenschaftliches Verfahren, das durchgeführt wird, um eine Entdeckung zu machen, eine Hypothese zu testen oder einen bekannten Fakt zu demonstrieren."@de ;
+    skos:topConceptOf <> .
+
+<problem_statement> a skos:Concept ;
+    skos:prefLabel "Problem Statement"@en ;
+    skos:prefLabel "Problemstellung"@de ;
+    skos:definition "A statement that defines or describes a problem or issue."@en ;
+    skos:definition "Eine Aussage, die ein Problem oder eine Fragestellung definiert oder beschreibt."@de ;
+    skos:topConceptOf <> .
+
+<self_assessment> a skos:Concept ;
+    skos:prefLabel "Self Assessment"@en ;
+    skos:prefLabel "Selbstbewertung"@de ;
+    skos:definition "An assessment of one's own abilities or performance."@en ;
+    skos:definition "Eine Bewertung der eigenen Fähigkeiten oder Leistungen."@de ;
+    skos:topConceptOf <> .
+
+<lecture> a skos:Concept ;
+    skos:prefLabel "Lecture"@en ;
+    skos:prefLabel "Vorlesung"@de ;
+    skos:definition "An educational talk to an audience, typically given by a teacher or professor."@en ;
+    skos:definition "Ein Bildungsgespräch für ein Publikum, typischerweise gehalten von einem Lehrer oder Professor."@de ;
+    skos:topConceptOf <> .
+
+<reading> a skos:Concept ;
+    skos:prefLabel "Reading"@en ;
+    skos:prefLabel "Lesen"@de ;
+    skos:definition "Text material that is read, typically for educational or informational purposes."@en ;
+    skos:definition "Textmaterial, das typischerweise zu Bildungs- oder Informationszwecken gelesen wird."@de ;
+    skos:topConceptOf <> .

--- a/lom_purpose.ttl
+++ b/lom_purpose.ttl
@@ -1,0 +1,66 @@
+@base <http://w3id.org/openeduhub/vocabs/lom_purpose/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<> a skos:ConceptScheme;
+    dct:title "LOM - Classification.Purpose"@en;
+    dct:title "LOM - Classification.Purpose"@de;
+    dct:creator "<https://wirlernenonline.de>" ;
+    dct:created "2024-02-23"^^xsd:date;
+    dct:license <http://creativecommons.org/publicdomain/zero/1.0/> ;
+    skos:hasTopConcept <discipline>, <idea>, <prerequisite>, <educational_objective>, <accessibility_restrictions>, <educational_level>, <skill_level>, <security_level>, <competency> .
+
+<discipline> a skos:Concept ;
+    skos:prefLabel "Fach"@de, "Discipline"@en ;
+    skos:definition "Das Lernobjekt zielt darauf ab, Fachwissen zu vermitteln."@de ;
+    skos:definition "The learning object aims to convey discipline knowledge."@en ;
+    skos:topConceptOf <> .
+
+<idea> a skos:Concept ;
+    skos:prefLabel "Unterrichtsidee"@de, "Idea"@en ;
+    skos:definition "Das Lernobjekt zielt darauf ab, Ideen und Konzepte zu vermitteln."@de ;
+    skos:definition "The learning object aims to convey ideas and concepts."@en ;
+    skos:topConceptOf <> .
+
+<prerequisite> a skos:Concept ;
+    skos:prefLabel "Lern-Voraussetzung"@de, "Prerequisite"@en ;
+    skos:definition "Das Lernobjekt vermittelt Voraussetzungen für weitere Lernobjekte."@de ;
+    skos:definition "The learning object serves as a prerequisite for further learning objects."@en ;
+    skos:topConceptOf <> .
+
+<educational_objective> a skos:Concept ;
+    skos:prefLabel "Lernziel"@de, "Educational Objective"@en ;
+    skos:definition "Das Lernobjekt zielt darauf ab, spezifische Lernziele zu erreichen."@de ;
+    skos:definition "The learning object aims to achieve specific educational objectives."@en ;
+    skos:topConceptOf <> .
+
+<accessibility_restrictions> a skos:Concept ;
+    skos:prefLabel "Barrierefreiheitseinschränkungen"@de, "Accessibility Restrictions"@en ;
+    skos:definition "Das Lernobjekt zielt darauf ab, den Zugang zu Bildungsressourcen zu erleichtern."@de ;
+    skos:definition "The learning object aims to facilitate access to educational resources."@en ;
+    skos:topConceptOf <> .
+
+<educational_level> a skos:Concept ;
+    skos:prefLabel "Unterrichtsniveau"@de, "Educational Level"@en ;
+    skos:definition "Das Lernobjekt zielt darauf ab, Unterrichtsniveaus zu vermitteln."@de ;
+    skos:definition "The learning object aims to convey educational levels."@en ;
+    skos:topConceptOf <> .
+
+<skill_level> a skos:Concept ;
+    skos:prefLabel "Fähigkeitsniveau"@de, "Skill Level"@en ;
+    skos:definition "Das Lernobjekt zielt darauf ab, Fähigkeitsniveaus zu vermitteln."@de ;
+    skos:definition "The learning object aims to convey skill levels."@en ;
+    skos:topConceptOf <> .
+
+<security_level> a skos:Concept ;
+    skos:prefLabel "Sicherheitsniveau"@de, "Security Level"@en ;
+    skos:definition "Das Lernobjekt zielt darauf ab, Sicherheitsniveaus zu vermitteln."@de ;
+    skos:definition "The learning object aims to convey security levels."@en ;
+    skos:topConceptOf <> .
+
+<competency> a skos:Concept ;
+    skos:prefLabel "Kompetenz"@de, "Competency"@en ;
+    skos:definition "Das Lernobjekt zielt darauf ab, Kompetenzen zu vermitteln."@de ;
+    skos:definition "The learning object aims to convey competencies."@en ;
+    skos:topConceptOf <> .

--- a/lom_relation_kind.ttl
+++ b/lom_relation_kind.ttl
@@ -1,0 +1,76 @@
+@base <http://w3id.org/openeduhub/vocabs/lom_relation_kind/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<> a skos:ConceptScheme;
+    dct:title "LOM - Relation.Kind"@en;
+    dct:title "LOM - Relation.Kind"@de;
+    dct:description "Nature of the relationship between this learning object and a target learning object."@en ;
+    dct:description "Art der Beziehung zwischen diesem Lernobjekt und einem Ziel-Lernobjekt."@de ;
+    dct:creator "<https://wirlernenonline.de>" ;
+    dct:created "2024-02-23"^^xsd:date;
+    dct:license <http://creativecommons.org/publicdomain/zero/1.0/> ;
+    skos:hasTopConcept <isVersionOf>, <hasVersion>, <isPartOf>, <hasPart>, <isBasedOn>, <isBasisFor>, <requires>, <isRequiredBy>, <references>, <isReferencedBy>, <isFormatOf>, <hasFormat> .
+
+<isVersionOf> a skos:Concept ;
+    skos:prefLabel "is version of"@en, "Ist Version von"@de ;
+    skos:definition "This resource is a version of another resource."@en ;
+    skos:definition "Diese Ressource ist eine Version einer anderen Ressource."@de ;
+    skos:topConceptOf <> .
+
+<hasVersion> a skos:Concept ;
+    skos:prefLabel "has version"@en, "Besitzt Version"@de ;
+    skos:topConceptOf <> .
+
+<isPartOf> a skos:Concept ;
+    skos:prefLabel "is part of"@en, "Ist Teil von"@de ;
+    skos:definition "This resource is part of another resource."@en ;
+    skos:definition "Diese Ressource ist ein Teil einer anderen Ressource."@de ;
+    skos:topConceptOf <> .
+
+<hasPart> a skos:Concept ;
+    skos:prefLabel "has part"@en, "Besitzt Teil"@de ;
+    skos:topConceptOf <> .
+
+<isBasedOn> a skos:Concept ;
+    skos:prefLabel "is based on"@en, "Basiert auf"@de ;
+    skos:definition "This resource is based on another resource."@en ;
+    skos:definition "Diese Ressource basiert auf einer anderen Ressource."@de ;
+    skos:topConceptOf <> .
+
+<isBasisFor> a skos:Concept ;
+    skos:prefLabel "is basis for"@en, "Ist Basis von"@de ;
+    skos:topConceptOf <> .
+
+<requires> a skos:Concept ;
+    skos:prefLabel "requires"@en, "Erfordert"@de ;
+    skos:definition "This resource requires another resource."@en ;
+    skos:definition "Diese Ressource erfordert eine andere Ressource."@de ;
+    skos:topConceptOf <> .
+
+<isRequiredBy> a skos:Concept ;
+    skos:prefLabel "is required by"@en, "Wird benötigt von"@de ;
+    skos:topConceptOf <> .
+
+<references> a skos:Concept ;
+    skos:prefLabel "references"@en, "Referenziert"@de ;
+    skos:definition "This resource references another resource."@en ;
+    skos:definition "Diese Ressource referenziert eine andere Ressource."@de ;
+    skos:topConceptOf <> .
+
+<isReferencedBy> a skos:Concept ;
+    skos:prefLabel "is referenced by"@en, "Ist bezogen auf"@de ;
+    skos:topConceptOf <> .
+
+<isFormatOf> a skos:Concept ;
+    skos:prefLabel "is format of"@en, "Ist Format von"@de ;
+    skos:definition "This resource is a format of another resource."@en ;
+    skos:definition "Diese Ressource ist ein Format einer anderen Ressource."@de ;
+    skos:topConceptOf <> .
+
+<hasFormat> a skos:Concept ;
+    skos:prefLabel "has format"@en, "Hat Format"@de ;
+    skos:definition "This resource has a specific format."@en ;
+    skos:definition "Diese Ressource hat ein bestimmtes Format."@de ;
+    skos:topConceptOf <> .

--- a/lom_required_technology_name.ttl
+++ b/lom_required_technology_name.ttl
@@ -1,0 +1,70 @@
+@base <http://w3id.org/openeduhub/vocabs/lom_required_technology_name/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<> a skos:ConceptScheme;
+    dct:title "LOM - Technical.Reqirement.OrComposite.Name"@de;
+    dct:title "LOM - Technical.Reqirement.OrComposite.Name"@en;
+    dct:description "Value range for the name of the technology required to use this learning object."@en;
+    dct:description "Wertebereich für den Namen der Technologie, die zur Verwendung dieses Lernobjekts erforderlich ist."@de;
+    dct:creator "<https://wirlernenonline.de>" ;
+    dct:created "2024-02-23"^^xsd:date;
+    dct:license <http://creativecommons.org/publicdomain/zero/1.0/> ;
+    skos:hasTopConcept <pc_dos>, <ms_windows>, <macos>, <unix>, <multi_os>, <none>, <any>, <netscape_communicator>, <ms_internet_explorer>, <opera>, <amaya> .
+
+<pc_dos> a skos:Concept ;
+    skos:prefLabel "pc-dos"@en ;
+    skos:prefLabel "PC-DOS"@de ;
+    skos:topConceptOf <> .
+
+<ms_windows> a skos:Concept ;
+    skos:prefLabel "ms-windows"@en ;
+    skos:prefLabel "MS Windows"@de ;
+    skos:topConceptOf <> .
+
+<macos> a skos:Concept ;
+    skos:prefLabel "mac os"@en ;
+    skos:prefLabel "MAC OS"@de ;
+    skos:topConceptOf <> .
+
+<unix> a skos:Concept ;
+    skos:prefLabel "unix"@en ;
+    skos:prefLabel "UNIX"@de ;
+    skos:topConceptOf <> .
+
+<multi_os> a skos:Concept ;
+    skos:prefLabel "multi-os"@en ;
+    skos:prefLabel "Multi-OS"@de ;
+    skos:topConceptOf <> .
+
+<none> a skos:Concept ;
+    skos:prefLabel "none"@en ;
+    skos:prefLabel "keine"@de ;
+    skos:topConceptOf <> .
+
+<any> a skos:Concept ;
+    skos:prefLabel "any"@en ;
+    skos:prefLabel "alle"@de ;
+    skos:topConceptOf <> .
+
+<netscape_communicator> a skos:Concept ;
+    skos:prefLabel "netscape communicator"@en ;
+    skos:prefLabel "Netscape Communicator"@de ;
+    skos:topConceptOf <> .
+
+<ms_internet_explorer> a skos:Concept ;
+    skos:prefLabel "ms internet explorer"@en ;
+    skos:prefLabel "MS Internet-Explorer"@de ;
+    skos:topConceptOf <> .
+
+<opera> a skos:Concept ;
+    skos:prefLabel "opera"@en ;
+    skos:prefLabel "Opera"@de ;
+    skos:topConceptOf <> .
+
+<amaya> a skos:Concept ;
+    skos:prefLabel "amaya"@en ;
+    skos:prefLabel "Amaya"@de ;
+    skos:topConceptOf <> .
+

--- a/lom_required_technology_type.ttl
+++ b/lom_required_technology_type.ttl
@@ -1,0 +1,24 @@
+@base <http://w3id.org/openeduhub/vocabs/lom_required_technology_type/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<> a skos:ConceptScheme;
+    dct:title "LOM - Technical.Reqirement.OrComposite.Type"@de;
+    dct:title "LOM - Technical.Reqirement.OrComposite.Type"@en;
+    dct:description "Value range for the technical capabilities necessary for using this learning object."@en;
+    dct:description "Wertebereich für die technischen Fähigkeiten, die zur Nutzung dieses Lernobjekts erforderlich sind, gemäß dem LOM-Standard."@de;
+    dct:creator "<https://wirlernenonline.de>" ;
+    dct:created "2024-02-23"^^xsd:date;
+    dct:license <http://creativecommons.org/publicdomain/zero/1.0/> ;
+    skos:hasTopConcept <operating_system>, <browser> .
+
+<operating_system> a skos:Concept ;
+    skos:prefLabel "Operating system"@en ;
+    skos:prefLabel "Betriebssystem"@de ;
+    skos:topConceptOf <> .
+
+<browser> a skos:Concept ;
+    skos:prefLabel "Browser"@en ;
+    skos:prefLabel "Browser"@de ;
+    skos:topConceptOf <> .

--- a/lom_role meta.ttl
+++ b/lom_role meta.ttl
@@ -1,0 +1,34 @@
+@base <http://w3id.org/openeduhub/vocabs/lom_role_meta/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<> a skos:ConceptScheme;
+    dct:title "LOM - Metametadata.Contribute.Role"@de;
+    dct:title "LOM - Metametadata.Contribute.Role"@en;
+    dct:description "Value range for the role of a contributor in the context of a learning resource according to the LOM standard."@en;
+    dct:description "Wertebereich für die Rolle eines Beitragenden im Kontext einer Lernressource gemäß dem LOM-Standard."@de;
+    dct:creator "<https://wirlernenonline.de>" ;
+    dct:created "2024-02-23"^^xsd:date;
+    dct:license <http://creativecommons.org/publicdomain/zero/1.0/> ;
+    skos:hasTopConcept <creator>, <enricher>, <provider>, <validator> .
+
+<creator> a skos:Concept ;
+    skos:prefLabel "Creator"@en ;
+    skos:prefLabel "Erstellung"@de ;
+    skos:topConceptOf <> .
+
+<enricher> a skos:Concept ;
+    skos:prefLabel "Enricher"@en ;
+    skos:prefLabel "Bearbeitung"@de ;
+    skos:topConceptOf <> .
+
+<provider> a skos:Concept ;
+    skos:prefLabel "Provider"@en ;
+    skos:prefLabel "Bereitstellung"@de ;
+    skos:topConceptOf <> .
+
+<validator> a skos:Concept ;
+    skos:prefLabel "Validator"@en ;
+    skos:prefLabel "Abnahme"@de ;
+    skos:topConceptOf <> .

--- a/lom_role.ttl
+++ b/lom_role.ttl
@@ -1,0 +1,117 @@
+@base <http://w3id.org/openeduhub/vocabs/lom_role/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<> a skos:ConceptScheme;
+    dct:title "LOM - Lifecycle.Contribute.Role"@de;
+    dct:title "LOM - Lifecycle.Contribute.Role"@en;
+    dct:description "Value range for the role of a person or organization in the context of a learning resource according to the LOM standard."@en;
+    dct:description "Wertebereich für die Rolle einer Person oder Organisation im Kontext einer Lernressource gemäß dem LOM-Standard."@de;
+    dct:creator "<https://wirlernenonline.de>" ;
+    dct:created "2024-02-23"^^xsd:date;
+    dct:license <http://creativecommons.org/publicdomain/zero/1.0/> ;
+    skos:hasTopConcept <author>, <publisher>, <initiator>, <terminator>, <validator>, <editor>, <graphic_designer>, <technical_implementer>, <content_provider>, <technical_validator>, <educational_validator>, <script_writer>, <instructional_designer>, <subject_matter_expert>, <unknown> .
+
+<author> a skos:Concept ;
+    skos:prefLabel "Author"@en ;
+    skos:prefLabel "Autor"@de ;
+    skos:definition "The person or organization responsible for creating the content of the learning resource."@en ;
+    skos:definition "Die Person oder Organisation, die für die Erstellung des Inhalts der Lernressource verantwortlich ist."@de ;
+    skos:topConceptOf <> .
+
+<publisher> a skos:Concept ;
+    skos:prefLabel "Publisher"@en ;
+    skos:prefLabel "Herausgeber"@de ;
+    skos:definition "The person or organization responsible for making the learning resource available."@en ;
+    skos:definition "Die Person oder Organisation, die dafür verantwortlich ist, die Lernressource verfügbar zu machen."@de ;
+    skos:topConceptOf <> .
+
+<initiator> a skos:Concept ;
+    skos:prefLabel "Initiator"@en ;
+    skos:prefLabel "Initiator"@de ;
+    skos:definition "The person or organization responsible for initiating the creation of the learning resource."@en ;
+    skos:definition "Die Person oder Organisation, die für die Initiierung der Erstellung der Lernressource verantwortlich ist."@de ;
+    skos:topConceptOf <> .
+
+<terminator> a skos:Concept ;
+    skos:prefLabel "Terminator"@en ;
+    skos:prefLabel "Beendung der Verfügbarkeit"@de ;
+    skos:definition "The person or organization responsible for terminating the availability of the learning resource."@en ;
+    skos:definition "Die Person oder Organisation, die für die Beendigung der Verfügbarkeit der Lernressource verantwortlich ist."@de ;
+    skos:topConceptOf <> .
+
+<validator> a skos:Concept ;
+    skos:prefLabel "Validator"@en ;
+    skos:prefLabel "Abnahme"@de ;
+    skos:definition "The person or organization responsible for validating the learning resource."@en ;
+    skos:definition "Die Person oder Organisation, die für die Validierung der Lernressource verantwortlich ist."@de ;
+    skos:topConceptOf <> .
+
+<editor> a skos:Concept ;
+    skos:prefLabel "Editor"@en ;
+    skos:prefLabel "Redaktion"@de ;
+    skos:definition "The person or organization responsible for editing the content of the learning resource."@en ;
+    skos:definition "Die Person oder Organisation, die für die Bearbeitung des Inhalts der Lernressource verantwortlich ist."@de ;
+    skos:topConceptOf <> .
+
+<graphic_designer> a skos:Concept ;
+    skos:prefLabel "Graphic Designer"@en ;
+    skos:prefLabel "Grafisches Design"@de ;
+    skos:definition "The person or organization responsible for designing the graphics of the learning resource."@en ;
+    skos:definition "Die Person oder Organisation, die für das Design der Grafiken der Lernressource verantwortlich ist."@de ;
+    skos:topConceptOf <> .
+
+<technical_implementer> a skos:Concept ;
+    skos:prefLabel "Technical Implementer"@en ;
+    skos:prefLabel "Programmierung"@de ;
+    skos:definition "The person or organization responsible for implementing the technical aspects of the learning resource."@en ;
+    skos:definition "Die Person oder Organisation, die für die Implementierung der technischen Aspekte der Lernressource verantwortlich ist."@de ;
+    skos:topConceptOf <> .
+
+<content_provider> a skos:Concept ;
+    skos:prefLabel "Content Provider"@en ;
+    skos:prefLabel "Materialbereitstellung"@de ;
+    skos:definition "The person or organization responsible for providing the content of the learning resource."@en ;
+    skos:definition "Die Person oder Organisation, die für die Bereitstellung des Inhalts der Lernressource verantwortlich ist."@de ;
+    skos:topConceptOf <> .
+
+<technical_validator> a skos:Concept ;
+    skos:prefLabel "Technical Validator"@en ;
+    skos:prefLabel "Technische Prüfung"@de ;
+    skos:definition "The person or organization responsible for validating the technical aspects of the learning resource."@en ;
+    skos:definition "Die Person oder Organisation, die für die Validierung der technischen Aspekte der Lernressource verantwortlich ist."@de ;
+    skos:topConceptOf <> .
+
+<educational_validator> a skos:Concept ;
+    skos:prefLabel "Educational Validator"@en ;
+    skos:prefLabel "pädagogische Prüfung"@de ;
+    skos:definition "The person or organization responsible for validating the educational aspects of the learning resource."@en ;
+    skos:definition "Die Person oder Organisation, die für die Validierung der pädagogischen Aspekte der Lernressource verantwortlich ist."@de ;
+    skos:topConceptOf <> .
+
+<script_writer> a skos:Concept ;
+    skos:prefLabel "Script Writer"@en ;
+    skos:prefLabel "Skript/Drehbuch"@de ;
+    skos:definition "The person or organization responsible for writing the script or scenario of the learning resource."@en ;
+    skos:definition "Die Person oder Organisation, die für das Verfassen des Drehbuchs oder Szenarios der Lernressource verantwortlich ist."@de ;
+    skos:topConceptOf <> .
+
+<instructional_designer> a skos:Concept ;
+    skos:prefLabel "Instructional Designer"@en ;
+    skos:prefLabel "Pädagogisches Konzept"@de ;
+    skos:definition "The person or organization responsible for designing the instructional aspects of the learning resource."@en ;
+    skos:definition "Die Person oder Organisation, die für das Design der instruktionalen Aspekte der Lernressource verantwortlich ist."@de ;
+    skos:topConceptOf <> .
+
+<subject_matter_expert> a skos:Concept ;
+    skos:prefLabel "Subject Matter Expert"@en ;
+    skos:prefLabel "Fachberatung"@de ;
+    skos:definition "The person or organization considered an expert in the subject matter of the learning resource."@en ;
+    skos:definition "Die Person oder Organisation, die als Experte für das Thema der Lernressource gilt."@de ;
+    skos:topConceptOf <> .
+
+<unknown> a skos:Concept ;
+    skos:prefLabel "Unknown"@en ;
+    skos:prefLabel "Unbekannt"@de ;
+    skos:topConceptOf <> .

--- a/lom_semantic_density.ttl
+++ b/lom_semantic_density.ttl
@@ -1,0 +1,39 @@
+@base <http://w3id.org/openeduhub/vocabs/lom_semantic_density/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<> a skos:ConceptScheme;
+    dct:title "LOM - Educational.SemanticDensity"@en;
+    dct:title "LOM - Educational.SemanticDensity"@de;
+    dct:description "The degree of conciseness of a learning object. The semantic density of a learning object may be estimated depending on the relation between the amount of information provided and the size, span or duration of the learning object."@en;
+    dct:description "Der Grad der Prägnanz eines Lernobjekts. Die semantische Dichte eines Lernobjekts kann anhand des Verhältnisses zwischen der Menge der bereitgestellten Informationen und der Größe, dem Umfang oder der Dauer des Lernobjekts geschätzt werden."@de;
+    dct:creator "<https://wirlernenonline.de>" ;
+    dct:created "2024-02-23"^^xsd:date;
+    dct:license <http://creativecommons.org/publicdomain/zero/1.0/> ;
+    skos:hasTopConcept <very_low>, <low>, <medium>, <high>, <very_high> .
+
+<very_low> a skos:Concept ;
+    skos:prefLabel "Very Low"@en ;
+    skos:prefLabel "Sehr gering"@de ;
+    skos:topConceptOf <> .
+
+<low> a skos:Concept ;
+    skos:prefLabel "Low"@en ;
+    skos:prefLabel "Gering"@de ;
+    skos:topConceptOf <> .
+
+<medium> a skos:Concept ;
+    skos:prefLabel "Medium"@en ;
+    skos:prefLabel "Mittel"@de ;
+    skos:topConceptOf <> .
+
+<high> a skos:Concept ;
+    skos:prefLabel "High"@en ;
+    skos:prefLabel "Hoch"@de ;
+    skos:topConceptOf <> .
+
+<very_high> a skos:Concept ;
+    skos:prefLabel "Very High"@en ;
+    skos:prefLabel "Sehr hoch"@de ;
+    skos:topConceptOf <> .

--- a/lom_status.ttl
+++ b/lom_status.ttl
@@ -1,0 +1,42 @@
+@base <http://w3id.org/openeduhub/vocabs/lom_status/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<> a skos:ConceptScheme;
+    dct:title "LOM - Lifecycle.Status"@de;
+    dct:title "LOM - Lifecycle.Status"@en;
+    dct:description "Value range for the status of a learning resource according to the LOM standard."@en;
+    dct:description "Wertebereich für den Status einer Lernressource gemäß dem LOM-Standard."@de;
+    dct:creator "<https://wirlernenonline.de>" ;
+    dct:created "2024-02-23"^^xsd:date;
+    dct:license <http://creativecommons.org/publicdomain/zero/1.0/> ;
+    skos:hasTopConcept <draft>, <final>, <revised>, <unavailable> .
+
+<draft> a skos:Concept ;
+    skos:prefLabel "Draft"@en ;
+    skos:prefLabel "Entwurfsversion"@de ;
+    skos:definition "The learning resource is in draft status."@en ;
+    skos:definition "Die Lernressource befindet sich im Entwurfsstatus."@de ;
+    skos:topConceptOf <> .
+
+<final> a skos:Concept ;
+    skos:prefLabel "Final"@en ;
+    skos:prefLabel "Endversion"@de ;
+    skos:definition "The learning resource is in final status."@en ;
+    skos:definition "Die Lernressource befindet sich im Endfassungsstatus."@de ;
+    skos:topConceptOf <> .
+
+<revised> a skos:Concept ;
+    skos:prefLabel "Revised"@en ;
+    skos:prefLabel "Endversion (geprüft)"@de ;
+    skos:definition "The learning resource is in revised status."@en ;
+    skos:definition "Die Lernressource befindet sich im Überarbeitungsstatus."@de ;
+    skos:topConceptOf <> .
+
+<unavailable> a skos:Concept ;
+    skos:prefLabel "Unavailable"@en ;
+    skos:prefLabel "Nicht verfügbar"@de ;
+    skos:definition "The learning resource is unavailable."@en ;
+    skos:definition "Die Lernressource ist nicht verfügbar."@de ;
+    skos:topConceptOf <> .

--- a/lom_structure.ttl
+++ b/lom_structure.ttl
@@ -1,0 +1,50 @@
+@base <http://w3id.org/openeduhub/vocabs/lom_structure/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<> a skos:ConceptScheme;
+    dct:title "LOM - General.Structure"@de;
+    dct:title "LOM - General.Structure"@en;
+    dct:description "Wertebereich für die grundlegende Organisationsstruktur eines Lernobjekts."@de;
+    dct:description "Value range for the basic organizational structure of a learning object."@en;
+    dct:creator "<https://wirlernenonline.de>" ;
+    dct:created "2024-02-23"^^xsd:date;
+    dct:license <http://creativecommons.org/publicdomain/zero/1.0/> ;
+    skos:hasTopConcept <atomic>, <collection>, <networked>, <hierarchical>, <linear> .
+
+
+<atomic> a skos:Concept ;
+    skos:prefLabel "atomic"@en ;
+    skos:prefLabel "Einzelobjekt"@de ;
+    skos:definition "The learning resource is not divided into smaller units."@en ;
+    skos:definition "Die Lernressource ist nicht in kleinere Einheiten unterteilt."@de ;
+    skos:topConceptOf <> .
+
+<collection> a skos:Concept ;
+    skos:prefLabel "collection"@en ;
+    skos:prefLabel "Sammlung"@de ;
+    skos:definition "The learning resource is a collection of multiple individual resources."@en ;
+    skos:definition "Die Lernressource ist eine Sammlung von mehreren einzelnen Ressourcen."@de ;
+    skos:topConceptOf <> .
+
+<networked> a skos:Concept ;
+    skos:prefLabel "networked"@en ;
+    skos:prefLabel "Vernetzt"@de ;
+    skos:definition "The learning resource is a network of resources accessible via the Internet or an intranet."@en ;
+    skos:definition "Die Lernressource ist ein Netzwerk von Lernressourcen, das über das Internet oder ein Intranet zugänglich ist."@de ;
+    skos:topConceptOf <> .
+
+<hierarchical> a skos:Concept ;
+    skos:prefLabel "hierarchical"@en ;
+    skos:prefLabel "Hierarchisch"@de ;
+    skos:definition "The learning resource is hierarchically structured, with individual parts or sections building upon one another."@en ;
+    skos:definition "Die Lernressource ist hierarchisch strukturiert, wobei einzelne Teile oder Abschnitte aufeinander aufbauen."@de ;
+    skos:topConceptOf <> .
+
+<linear> a skos:Concept ;
+    skos:prefLabel "linear"@en ;
+    skos:prefLabel "Linear"@de ;
+    skos:definition "The learning resource has a linear structure, progressing sequentially from start to finish."@en ;
+    skos:definition "Die Lernressource hat eine lineare Struktur, die sich sequenziell vom Anfang bis zum Ende entwickelt."@de ;
+    skos:topConceptOf <> .


### PR DESCRIPTION
In order to enable validation against the LOM schema  (https://github.com/jbroadway/scorm/blob/master/samples/AllGolfExamples/ContentPackagingMetadata_SCORM20043rdEdition/common/vocabValues.xsd), the corresponding valuespaces were first created as ttl and will then be used to define mappings from our vocabulary to the LOM values.